### PR TITLE
Add support for compartments

### DIFF
--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -1,34 +1,64 @@
 export Species, @Species, Environment, ∅
 
-# Chemical species are lowered to DependentVariable
-Species(name, value = nothing, value_type = typeof(value)) =
-             Variable(name, :Species, value, value_type, nothing)
-dvar_species(s) = DependentVariable(s.name, s.value, s.value_type, s.diff)
+# Default compartment. A compartment is just a SciComp variable (any subtype!)
+const _global_compartment_ = Constant(:_global_compartment_,1)
 
-# Allows to create several Species with or without default values as @Species s1, s2, s3 = 2.5
-macro Species(x...)
-        esc(SciCompDSL._parse_vars("Species", :Species, x))
+# Chemical species like Variable but they exist inside a compartment and it
+# is lowered to a DependentVariable
+struct Species <: Expression
+    name::Symbol
+    compartment::Variable
+    value
+    value_type::DataType
 end
+# Facilitate construction of Species
+Species(name, value = nothing, value_type = typeof(value)) =
+             Species(name, _global_compartment_, value, value_type)
+macro Species(x...)
+     esc(SciCompDSL._parse_vars("Species", :Species, x))
+end
+Base.in(s::Species, c::Variable) = Species(s.name, c, s.value, s.value_type)
+# Lowering to DependentVariable
+SciCompDSL.DependentVariable(s::Species) = SciCompDSL.DependentVariable(s.name, s.value, s.value_type)
 
+# Need to behave like a variable for printing and arithmetic (adapted from SciCompDSL.jl)
+Base.Expr(x::Species) = :($(x.name))
+function Base.show(io::IO, A::Species)
+        str = "Species($(A.name))"
+        if A.value != nothing
+            str *= ", value = " * string(A.value)
+        end
+        print(io,str)
+end
+function Base.:(==)(x::Species,y::Species)
+    x.name == y.name && x.compartment == y.compartment && x.value == y.value &&
+    x.value_type == y.value_type
+end
 
 # To represent sources and sinks in a reaction (creation/degration to/from nothing)
 struct Environment end
 const ∅ = Environment()
 
+
 # The basic element of a reaction. Stoichiometry does not have to be a literal
 struct Reactant
-    species::Variable
+    species::Species
     stoich::Variable
 end
+
 
 # The formula of a reaction. The type of arrow is stored as type parameter
 struct Formula
     arrow::Symbol
+    compartment::Variable
     substrates::Vector{Reactant}
     products::Vector{Reactant}
 end
-Base.:(==)(r1::Formula, r2::Formula) = r1.substrates == r2.substrates &&
-    r1.products == r2.products && r1.arrow == r2.arrow
+Formula(arrow, substrates, products) = Formula(arrow, _global_compartment_, substrates, products)
+Base.:(==)(f1::Formula, f2::Formula) = f1.substrates == f2.substrates &&
+    f1.products == f2.products && f1.arrow == f2.arrow && f1.compartment == f2.compartment
+# Change default compartment of a Formula
+Base.in(f::Formula, c::Variable) = Formula(f.arrow, c, f.substrates, f.products)
 
 # Reaction holds formula and its rate equation in SciComp IR
 struct Reaction

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,3 +50,11 @@ eq2 = [∅ ⟺ x ~ gₓ*(xₒ - x),
        y ⟺ ∅ ~ vₛ*y/(Kₘ + y)]
 ode2 = ReactionODE(eq2, t)
 generate_ode_function(ode2)
+
+# Transport across compartments
+@Param kf kb V₁ Vₘ V₂
+s₁ = Species(:s₁) ∈ V₁
+s₂ = Species(:s₂) ∈ V₂
+eq3 = [(s₁ ⟺ s₂) ∈ Vₘ ~ kf*s₁ - kb*s₂]
+ode3 = ReactionODE(eq3, t)
+generate_ode_function(ode3)


### PR DESCRIPTION
A compartment can be any SciComp variable.
Species is a now a specific type with compartment information and behaves similarly to a SciComp variable.
Default compartment and ignore compartment scaling when they are the same.
Closes #2